### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 This is a Model Context Protocol (MCP) server that provides tools for interacting with the Eventbrite API. It allows AI assistants to search for events, get event details, retrieve venue information, and more.
 
+<a href="https://glama.ai/mcp/servers/ev69dbqhrk">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/ev69dbqhrk/badge" alt="Eventbrite Server MCP server" />
+</a>
+
 ## Features
 
 - Search for events based on various criteria (location, date, category, etc.)


### PR DESCRIPTION
This PR adds a badge for the [Eventbrite MCP Server](https://glama.ai/mcp/servers/ev69dbqhrk) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/ev69dbqhrk">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/ev69dbqhrk/badge" alt="Eventbrite Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly asses that the MCP server is safe, server capabilities, and instructions for installing the server.